### PR TITLE
reformat tagWidget display and format sidebar for mobile display

### DIFF
--- a/src/components/catWidget.js
+++ b/src/components/catWidget.js
@@ -21,7 +21,7 @@ const categories = data.allWpCategory.nodes
     <div style={style.catWidgetWrapper}>
         <h3>Categories</h3>
         <ul className={style.catUnorderedList}>
-            {categories.map((cat, index) => (
+            {categories.map((cat, index) => index < 5 && (
                 <li>
                     <Link key={index} to={cat.link}>
                         {cat.name}

--- a/src/components/catWidget.module.css
+++ b/src/components/catWidget.module.css
@@ -5,5 +5,5 @@
   .catUnorderedList li a {
     text-decoration: none;
     font-family: 'Cabin', sans-serif;
-    font-weight: bold;
+    /* font-weight: bold; */
   }

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Col } from 'react-bootstrap'
+import { Col, Row } from 'react-bootstrap'
 import { useStaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
 import * as style from "./sidebar.module.css"
@@ -25,21 +25,26 @@ function Sidebar({}) {
 const image = data.file
 
   return (
-    <Col xs={12} sm={12} md={12} lg={4} xl={3}>
-        <div className={style.sidebarWrapper}>
-            <Img
-                className="d-block w-100"
-                fluid={image.childImageSharp.fluid}
-                alt={image.name}
-            />
-            <h3>Sidebar Area</h3>
-            <p>
-                Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.
-            </p>
-            {/* <SidebarNav/> */}
-            <CatWidget/>
-            <TagWidget/>
-        </div>
+    <Col xs={12} sm={12} md={12} lg={4} xl={3} className={style.sidebarWrapper}>
+            <Row>
+                <Col xs={12} sm={6} lg={12} className={style.sidebar1st}>
+                    <Img
+                        className="d-block w-100"
+                        fluid={image.childImageSharp.fluid}
+                        alt={image.name}
+                    />
+                    <h3>Sidebar Area</h3>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.
+                    </p>
+                    {/* <SidebarNav/> */}
+                </Col>
+                <Col xs={12} sm={6} lg={12} className={style.sidebar2nd}>
+                    <CatWidget/>
+                    <TagWidget/>
+                </Col>
+            </Row>
+
     </Col>
   )
 }

--- a/src/components/sidebar.module.css
+++ b/src/components/sidebar.module.css
@@ -1,5 +1,5 @@
 .sidebarWrapper {
-  margin: 1rem auto;
+  margin: 1rem auto 2rem;
   /* padding: 1rem; */
   /* background-color: #9C9B35; */
 }
@@ -8,12 +8,9 @@
   margin-top: 1rem;
 }
 
-.catUnorderedList {
-  list-style: none;
-  margin-left: 0;
-}
-.catUnorderedList li a {
-  text-decoration: none;
-  font-family: 'Cabin', sans-serif;
-  font-weight: bold;
+/*Stack columns on mobile*/
+@media only screen and (max-width: 991px) {
+  .sidebar2nd {
+    text-align: center;
+  }
 }

--- a/src/components/tagWidget.js
+++ b/src/components/tagWidget.js
@@ -20,15 +20,14 @@ const tags = data.allWpTag.nodes
   return (
     <div style={style.tagWidgetWrapper}>
         <h3>Tags</h3>
-        <ul className={style.tagUnorderedList}>
-            {tags.map((tag, index) => (
-                <li>
-                    <Link key={index} to={tag.link}>
-                        {tag.name}
-                    </Link>
-                </li>
-            ))}
-        </ul>
+        <div className={style.tagUnorderedList}>
+            {tags.map((tag, index) => [
+                index > 0 && ", ",
+                <Link key={index} to={tag.link}>
+                    {tag.name}
+                </Link>,
+            ])}
+        </div>
     </div>
   )
 }

--- a/src/components/tagWidget.module.css
+++ b/src/components/tagWidget.module.css
@@ -2,8 +2,8 @@
     list-style: none;
     margin-left: 0;
   }
-  .tagUnorderedList li a {
-    text-decoration: none;
-    font-family: 'Cabin', sans-serif;
-    font-weight: bold;
+  .tagUnorderedList a {
+    /* text-decoration: none; */
+    /* font-family: 'Cabin', sans-serif; */
+    /* font-weight: bold; */
   }


### PR DESCRIPTION
-tagWidget tag list separated by commas.
-finetune columns grid at mobile sizes.
-limit the number of tag and category items displayed.